### PR TITLE
Add 16bit support to Ascii::AppendDec()

### DIFF
--- a/OpenHome/Ascii.cpp
+++ b/OpenHome/Ascii.cpp
@@ -165,6 +165,16 @@ TUint Ascii::AppendDec(Bwx& aBuffer, TInt8 aValue)
     return AppendDec(aBuffer, (TInt)aValue);
 }
 
+TUint Ascii::AppendDec(Bwx& aBuffer, TUint16 aValue)
+{
+    return AppendDec(aBuffer, (TUint)aValue);
+}
+
+TUint Ascii::AppendDec(Bwx& aBuffer, TInt16 aValue)
+{
+    return AppendDec(aBuffer, (TInt)aValue);
+}
+
 /// Convert the supplied value to an decimal string and append it to
 /// the specified buffer.
 

--- a/OpenHome/Ascii.h
+++ b/OpenHome/Ascii.h
@@ -90,6 +90,8 @@ public:
 
     static TUint AppendDec(Bwx& aBuffer, TUint8 aValue);
     static TUint AppendDec(Bwx& aBuffer, TInt8 aValue);
+    static TUint AppendDec(Bwx& aBuffer, TUint16 aValue);
+    static TUint AppendDec(Bwx& aBuffer, TInt16 aValue);
     static TUint AppendDec(Bwx& aBuffer, TInt aValue);
     static TUint AppendDec(Bwx& aBuffer, TUint aValue);
     static TUint AppendDec(Bwx& aBuffer, TInt64 aValue);


### PR DESCRIPTION
I've add an overload to Ascii::AppendDec() that supports both signed and unsigned 16bit integers explicitly.
