### PR TITLE
Adding missing dependency to ohNet.net.dll target

### DIFF
--- a/Common.mak
+++ b/Common.mak
@@ -813,7 +813,7 @@ TestsCs: TestProxyCs TestDvDeviceCs TestCpDeviceDvCs TestPerformanceDv TestPerfo
 
 Tests: TestsNative TestsCs
 
-$(objdir)ohNet.net.dll: \
+$(objdir)ohNet.net.dll: make_obj_dir \
 	$(csCp)CpDevice.cs \
 	$(csCp)CpDeviceUpnp.cs \
 	$(csCp)CpProxy.cs \


### PR DESCRIPTION
My first pull request so hope it's been done correctly. I can't seem to exclude the merge from this request, but hopefully it's inconsequential.

Here's the comments on the fix:

If ohNet.net.dll is being built clean and independently, the C# compiler
exits because the target directory doesn't yet exist. This is resolved
by adding the make_object_dir dependency (bringing it in line with the
ohNetCore target).

And a little context from this thread:

http://forum.openhome.org/showthread.php?tid=1258&pid=2395#pid2395

Hope this is useful / correct. I haven't worked with nmake previously but the fix works on my machine.

Matthew