### PR TITLE
TextTransform: fix error message about missing input file(s)

### DIFF
--- a/OpenHome/Net/T4/TextTemplating/TextTransform/TextTransform.cs
+++ b/OpenHome/Net/T4/TextTemplating/TextTransform/TextTransform.cs
@@ -70,7 +70,7 @@ namespace Mono.TextTemplating
 			inputFile = remainingArgs [0];
 			
 			if (!File.Exists (inputFile)) {
-				Console.WriteLine ("Input file '{0}' does not exist.");
+				Console.WriteLine ("Input file '{0}' does not exist.", inputFile);
 				return -1;
 			}
 			


### PR DESCRIPTION
I noticed that `TextTransform` outputs an error message with a placeholder instead of the actual input file name/path if the `T4/Templates` directory is missing.