### PR TITLE
Add possibility to retrieve the client's User-Agent from IDviInvocation

### DIFF
--- a/OpenHome/Http.cpp
+++ b/OpenHome/Http.cpp
@@ -929,6 +929,29 @@ void HttpHeaderAccessControlRequestMethod::Process(const Brx& aValue)
 }
 
 
+// HttpHeaderUserAgent
+
+const Brx& HttpHeaderUserAgent::UserAgent() const
+{
+    return (iUserAgent);
+}
+
+TBool HttpHeaderUserAgent::Recognise(const Brx& aHeader)
+{
+    return Ascii::CaseInsensitiveEquals(aHeader, Http::kHeaderUserAgent);
+}
+
+void HttpHeaderUserAgent::Process(const Brx& aValue)
+{
+    try {
+        iUserAgent.ReplaceThrow(aValue);
+        SetReceived();
+    }
+    catch (BufferOverflow&) {
+    }
+}
+
+
 // ReaderHttpChunked
 
 ReaderHttpChunked::ReaderHttpChunked(IReader& aReader)

--- a/OpenHome/Http.cpp
+++ b/OpenHome/Http.cpp
@@ -179,6 +179,11 @@ void Http::WriteHeaderConnectionClose(WriterHttpHeader& aWriter)
     aWriter.WriteHeader(Http::kHeaderConnection, Http::kConnectionClose);
 }
 
+void Http::WriteHeaderUserAgent(WriterHttpHeader& aWriter, const Brx& aUserAgent)
+{
+    aWriter.WriteHeader(Http::kHeaderUserAgent, aUserAgent);
+}
+
 // HttpStatus
 
 TUint HttpStatus::Code() const
@@ -1218,7 +1223,7 @@ TUint HttpReader::WriteRequest(const Uri& aUri)
         iWriterRequest.WriteMethod(Http::kMethodGet, aUri.PathAndQuery(), Http::eHttp11);
         Http::WriteHeaderHostAndPort(iWriterRequest, aUri.Host(), port);
         if (iUserAgent.Bytes() > 0) {
-            iWriterRequest.WriteHeader(Http::kHeaderUserAgent, iUserAgent);
+            Http::WriteHeaderUserAgent(iWriterRequest, iUserAgent);
         }
         Http::WriteHeaderConnectionClose(iWriterRequest);
         iWriterRequest.WriteFlush();

--- a/OpenHome/Http.h
+++ b/OpenHome/Http.h
@@ -114,6 +114,7 @@ public:
     static void WriteHeaderContentLength(WriterHttpHeader& aWriter, TUint aLength);
     static void WriteHeaderContentType(WriterHttpHeader& aWriter, const Brx& aType);
     static void WriteHeaderConnectionClose(WriterHttpHeader& aWriter);
+    static void WriteHeaderUserAgent(WriterHttpHeader& aWriter, const Brx& aUserAgent);
 };
 
 class HttpStatus

--- a/OpenHome/Http.h
+++ b/OpenHome/Http.h
@@ -450,6 +450,18 @@ private:
     Bws<kMaxMethodBytes> iMethod;
 };
 
+class HttpHeaderUserAgent : public HttpHeader
+{
+    static const TUint kMaxUserAgentBytes = 1000;
+public:
+    const Brx& UserAgent() const;
+private:
+    virtual TBool Recognise(const Brx& aHeader);
+    virtual void Process(const Brx& aValue);
+private:
+    Bws<kMaxUserAgentBytes> iUserAgent;
+};
+
 class ReaderHttpChunked : public IReader
 {
     static const TUint kChunkSizeBufBytes = 10;

--- a/OpenHome/Net/Bindings/C/Device/DvInvocation.h
+++ b/OpenHome/Net/Bindings/C/Device/DvInvocation.h
@@ -47,6 +47,15 @@ typedef const char* (STDCALL *DvInvocationResourceUriPrefix)(void* aPtr);
 typedef void (STDCALL *DvInvocationClientEndpoint)(void* aPtr, TIpAddress* aClientAddress, uint32_t* aClientPort);
 
 /**
+ * Read the user agent of the client which has invoked this action.
+ *
+ * @param[in]  aPtr  aInvocationPtr passed to the action
+ * @param[out] aUserAgent  User agent of client
+ * @param[out] aLen  Length (in bytes) of aUserAgent.
+ */
+typedef void (STDCALL *DvInvocationClientUserAgent)(void* aPtr, const char** aUserAgent, uint32_t* aLen);
+
+/**
  * Table of function pointers passed to invoked actions.
  */
 typedef struct IDvInvocationC
@@ -55,6 +64,7 @@ typedef struct IDvInvocationC
     DvInvocationAdapter iAdapter;
     DvInvocationResourceUriPrefix iResourceUriPrefix;
     DvInvocationClientEndpoint iClientEndpoint;
+    DvInvocationClientUserAgent iClientUserAgent;
 }
 IDvInvocationC;
 

--- a/OpenHome/Net/Bindings/C/Device/DvInvocationC.cpp
+++ b/OpenHome/Net/Bindings/C/Device/DvInvocationC.cpp
@@ -47,3 +47,15 @@ void DvInvocationCPrivate::ClientEndpoint(void* aPtr, TIpAddress* aClientAddress
     *aClientAddress = ep.Address();
     *aClientPort = ep.Port();
 }
+
+void DvInvocationCPrivate::ClientUserAgent(void* aPtr, const char** aUserAgent, uint32_t* aLen)
+{
+    IDviInvocation& invocation = DvInvocationCPrivate::Invocation(aPtr);
+    *aLen = invocation.ClientUserAgent().Bytes();
+    if (*aLen <= 0) {
+        *aUserAgent = NULL;
+    }
+    else {
+        *aUserAgent = (const char*)invocation.ClientUserAgent().Ptr();
+    }
+}

--- a/OpenHome/Net/Bindings/C/Device/DvInvocationPrivate.h
+++ b/OpenHome/Net/Bindings/C/Device/DvInvocationPrivate.h
@@ -21,6 +21,7 @@ private:
     static TIpAddress STDCALL Adapter(void* aPtr);
     static const char* STDCALL ResourceUriPrefix(void* aPtr);
     static void STDCALL ClientEndpoint(void* aPtr, TIpAddress* aClientAddress, uint32_t* aClientPort);
+    static void STDCALL ClientUserAgent(void* aPtr, const char** aUserAgent, uint32_t* aLen);
 private:
     IDviInvocation& iInvocation;
     IDvInvocationC iFnTable;

--- a/OpenHome/Net/Bindings/C/Device/DvProvider.h
+++ b/OpenHome/Net/Bindings/C/Device/DvProvider.h
@@ -234,6 +234,15 @@ DllExport void STDCALL DvInvocationGetResourceUriPrefix(DvInvocationC aInvocatio
 DllExport void STDCALL DvInvocationGetClientEndpoint(DvInvocationC aInvocation, TIpAddress* aAddress, uint32_t* aPort);
 
 /**
+ * Get the client's user agent.
+ *
+ * @param[in]  aInvocation  Invocation handle.  Passed to OhNetCallbackDvInvocation.
+ * @param[out] aUserAgent   User agent of client.
+ * @param[out] aLen         Length (in bytes) of aUserAgent.
+ */
+DllExport void STDCALL DvInvocationGetClientUserAgent(DvInvocationC aInvocation, const char** aUserAgent, uint32_t* aLen);
+
+/**
  * Begin reading (input arguments for) an invocation
  *
  * Must be called before the values of any input arguments are read.

--- a/OpenHome/Net/Bindings/C/Device/DvProviderC.cpp
+++ b/OpenHome/Net/Bindings/C/Device/DvProviderC.cpp
@@ -191,6 +191,18 @@ void STDCALL DvInvocationGetClientEndpoint(DvInvocationC aInvocation, TIpAddress
     *aPort = ep.Port();
 }
 
+void STDCALL DvInvocationGetClientUserAgent(DvInvocationC aInvocation, const char** aUserAgent, uint32_t* aLen)
+{
+    IDviInvocation* invocation = InvocationFromHandle(aInvocation);
+    *aLen = invocation->ClientUserAgent().Bytes();
+    if (*aLen <= 0) {
+        *aUserAgent = NULL;
+    }
+    else {
+        *aUserAgent = (const char*)invocation->ClientUserAgent().Ptr();
+    }
+}
+
 int32_t STDCALL DvInvocationReadStart(DvInvocationC aInvocation)
 {
     IDviInvocation* invocation = InvocationFromHandle(aInvocation);

--- a/OpenHome/Net/Bindings/C/OhNet.h
+++ b/OpenHome/Net/Bindings/C/OhNet.h
@@ -481,6 +481,14 @@ DllExport void STDCALL OhNetInitParamsSetDvWebSocketPort(OhNetHandleInitParams a
 DllExport void STDCALL OhNetInitParamsSetDvEnableBonjour(OhNetHandleInitParams aParams, const char* aHostName);
 
 /**
+ * Set the user agent used in HTTP requests.
+ *
+ * @param[in] aParams          Initialisation params
+ * @param[in] aUserAgent       HTTP user agent
+ */
+DllExport void STDCALL OhNetInitParamsSetUserAgent(OhNetHandleInitParams aParams, const char* aHostName);
+
+/**
  * Query the tcp connection timeout
  *
  * @param[in] aParams          Initialisation params

--- a/OpenHome/Net/Bindings/C/OhNetC.cpp
+++ b/OpenHome/Net/Bindings/C/OhNetC.cpp
@@ -277,6 +277,12 @@ void STDCALL OhNetInitParamsSetDvEnableBonjour(OhNetHandleInitParams aParams, co
     ip->SetDvEnableBonjour(aHostName);
 }
 
+void STDCALL OhNetInitParamsSetUserAgent(OhNetHandleInitParams aParams, const char* aUserAgent)
+{
+    InitialisationParams* ip = reinterpret_cast<InitialisationParams*>(aParams);
+    ip->SetUserAgent(aUserAgent);
+}
+
 uint32_t STDCALL OhNetInitParamsTcpConnectTimeoutMs(OhNetHandleInitParams aParams)
 {
     InitialisationParams* ip = reinterpret_cast<InitialisationParams*>(aParams);

--- a/OpenHome/Net/Bindings/Cpp/Device/DvInvocation.h
+++ b/OpenHome/Net/Bindings/Cpp/Device/DvInvocation.h
@@ -16,6 +16,7 @@ public:
     virtual TIpAddress Adapter() const = 0;
     virtual const char* ResourceUriPrefix() const = 0;
     virtual void GetClientEndpoint(TIpAddress& aClientAddress, uint32_t& aClientPort) const = 0;
+    virtual std::string ClientUserAgent() const = 0;
     virtual void ReportError(uint32_t aCode, const std::string& aDescription) = 0; // throws
     virtual ~IDvInvocationStd() {}
 };
@@ -30,6 +31,7 @@ private:
     TIpAddress Adapter() const;
     const char* ResourceUriPrefix() const;
     void GetClientEndpoint(TIpAddress& aClientAddress, uint32_t& aClientPort) const;
+    std::string ClientUserAgent() const;
     void ReportError(uint32_t aCode, const std::string& aDescription);
 private:
     DvInvocationStd(const DvInvocationStd &);

--- a/OpenHome/Net/Bindings/Cpp/Device/DvInvocationStd.cpp
+++ b/OpenHome/Net/Bindings/Cpp/Device/DvInvocationStd.cpp
@@ -33,6 +33,11 @@ void DvInvocationStd::GetClientEndpoint(TIpAddress& aClientAddress, uint32_t& aC
     aClientPort = ep.Port();
 }
 
+std::string DvInvocationStd::ClientUserAgent() const
+{
+    return std::string((const char*)iInvocation.ClientUserAgent().Ptr(), iInvocation.ClientUserAgent().Bytes());
+}
+
 void DvInvocationStd::ReportError(uint32_t aCode, const std::string& aDescription)
 {
     Brn desc((const TByte*)aDescription.c_str(), (TUint)aDescription.length());

--- a/OpenHome/Net/Bindings/Cs/Device/DvProvider.cs
+++ b/OpenHome/Net/Bindings/Cs/Device/DvProvider.cs
@@ -304,6 +304,11 @@ namespace OpenHome.Net.Device
         /// <param name="aAddress">IPv4 address in network byte order</param>
         /// <param name="aPort">Client's port [1..65535]</param>
         void GetClientEndpoint(out uint aAddress, out uint aPort);
+        /// <summary>
+        /// Get the user agent provided by the client.
+        /// </summary>
+        /// <returns>The clien'ts user agent.</returns>
+        string ClientUserAgent();
     }
 
     /// <summary>
@@ -336,6 +341,12 @@ namespace OpenHome.Net.Device
         [DllImport("ohNet")]
 #endif
         static extern void DvInvocationGetClientEndpoint(IntPtr aInvocation, out uint aAddress, out uint aPort);
+#if IOS
+        [DllImport("__Internal")]
+#else
+        [DllImport("ohNet")]
+#endif
+        static extern void DvInvocationGetClientUserAgent(IntPtr aInvocation, out IntPtr aUserAgent, out uint aLen);
 #if IOS
         [DllImport("__Internal")]
 #else
@@ -510,6 +521,18 @@ namespace OpenHome.Net.Device
             DvInvocationGetClientEndpoint(iHandle, out address, out port);
             aAddress = address;
             aPort = port;
+        }
+        /// <summary>
+        /// Get the user agent provided by the client.
+        /// </summary>
+        /// <returns>The clien'ts user agent.</returns>
+        public string ClientUserAgent()
+        {
+            IntPtr cUserAgent;
+            uint len;
+            DvInvocationGetClientUserAgent(iHandle, out cUserAgent, out len);
+            String userAgent = InteropUtils.PtrToStringUtf8(cUserAgent, len);
+            return userAgent;
         }
         /// <summary>
         /// Begin reading (input arguments for) an invocation

--- a/OpenHome/Net/Bindings/Cs/OhNet.cs
+++ b/OpenHome/Net/Bindings/Cs/OhNet.cs
@@ -529,6 +529,11 @@ namespace OpenHome.Net.Core
         /// </summary>
         /// <remarks>Only used if DvEnableBonjour is true.</remarks>
         public string DvMdnsHostName { private get; set; }
+        
+        /// <summary>
+        /// User agent used in HTTP requests.
+        /// </summary>
+        public string UserAgent { get; set; }
 
         private uint iDvUpnpWebServerPort;
 
@@ -718,6 +723,12 @@ namespace OpenHome.Net.Core
         [DllImport("ohNet")]
 #endif
         static extern void OhNetInitParamsSetIncludeLoopbackNetworkAdapter(IntPtr aParams);
+#if IOS
+        [DllImport("__Internal")]
+#else
+        [DllImport("ohNet")]
+#endif
+        static extern void OhNetInitParamsSetUserAgent(IntPtr aParams, IntPtr aUserAgent);
 #if IOS
         [DllImport("__Internal")]
 #else
@@ -938,6 +949,9 @@ namespace OpenHome.Net.Core
                 }
                 OhNetInitParamsSetIncludeLoopbackNetworkAdapter(nativeParams);
             }
+            IntPtr userAgent = InteropUtils.StringToHGlobalUtf8(UserAgent);
+            OhNetInitParamsSetUserAgent(nativeParams, userAgent);
+            Marshal.FreeHGlobal(userAgent);
             return nativeParams;
         }
         internal static void FreeNativeInitParams(IntPtr aNativeInitParams)

--- a/OpenHome/Net/Bindings/Java/DvInvocation.c
+++ b/OpenHome/Net/Bindings/Java/DvInvocation.c
@@ -91,6 +91,23 @@ JNIEXPORT jint JNICALL Java_org_openhome_net_device_DvInvocation_DvInvocationGet
 #endif
 }
 
+
+/*
+ * Class:     org_openhome_net_device_DvInvocation
+ * Method:    DvInvocationGetClientUserAgent
+ * Signature: (J)Ljava/lang/String;
+ */
+JNIEXPORT jstring JNICALL Java_org_openhome_net_device_DvInvocation_DvInvocationGetClientUserAgent
+  (JNIEnv *aEnv, jclass aClass, jlong aInvocation)
+{
+    DvInvocationC invocation = (DvInvocationC) (size_t)aInvocation;
+    const char* userAgent;
+    uint32_t len;
+	
+    DvInvocationGetClientUserAgent(invocation, &userAgent, &len);
+    return (*aEnv)->NewStringUTF(aEnv, userAgent);
+}
+
 /*
  * Class:     org_openhome_net_device_DvInvocation
  * Method:    DvInvocationGetClientPort

--- a/OpenHome/Net/Bindings/Java/InitParams.c
+++ b/OpenHome/Net/Bindings/Java/InitParams.c
@@ -673,6 +673,22 @@ JNIEXPORT void JNICALL Java_org_openhome_net_core_InitParams_OhNetInitParamsSetD
 
 /*
  * Class:     org_openhome_net_core_InitParams
+ * Method:    OhNetInitParamsSetUserAgent
+ * Signature: (JLjava/lang/String;)V
+ */
+JNIEXPORT void JNICALL Java_org_openhome_net_core_InitParams_OhNetInitParamsSetUserAgent
+(JNIEnv *aEnv, jclass aClass, jlong aParams, jstring aUserAgent)
+{
+    OhNetHandleInitParams params = (OhNetHandleInitParams) (size_t)aParams;
+    const char* userAgent = (*aEnv)->GetStringUTFChars(aEnv, aUserAgent, NULL);
+    aClass = aClass;
+
+    OhNetInitParamsSetUserAgent(params, userAgent);
+    (*aEnv)->ReleaseStringUTFChars(aEnv, aUserAgent, userAgent);
+}
+
+/*
+ * Class:     org_openhome_net_core_InitParams
  * Method:    OhNetInitParamsSetLogOutput
  * Signature: (JLorg/openhome/net/core/IMessageListener;)J
  */

--- a/OpenHome/Net/Bindings/Java/InitParams.h
+++ b/OpenHome/Net/Bindings/Java/InitParams.h
@@ -329,6 +329,14 @@ JNIEXPORT void JNICALL Java_org_openhome_net_core_InitParams_OhNetInitParamsSetD
 
 /*
  * Class:     org_openhome_net_core_InitParams
+ * Method:    OhNetInitParamsSetUserAgent
+ * Signature: (JLjava/lang/String;)V
+ */
+JNIEXPORT void JNICALL Java_org_openhome_net_core_InitParams_OhNetInitParamsSetUserAgent
+(JNIEnv *, jclass, jlong, jstring);
+
+/*
+ * Class:     org_openhome_net_core_InitParams
  * Method:    OhNetInitParamsSetLogOutput
  * Signature: (JLorg/openhome/net/core/IMessageListener;)J
  */

--- a/OpenHome/Net/Bindings/Java/org/openhome/net/core/InitParams.java
+++ b/OpenHome/Net/Bindings/Java/org/openhome/net/core/InitParams.java
@@ -63,6 +63,7 @@ public class InitParams
 	private static native void OhNetInitParamsSetDvUpnpServerPort(long aParams, int aPort);
 	private static native void OhNetInitParamsSetDvWebSocketPort(long aParams, int aPort);
 	private static native void OhNetInitParamsSetDvEnableBonjour(long aParams, String aHostName);
+	private static native void OhNetInitParamsSetUserAgent(long aParams, String aHostName);
     private static native long OhNetInitParamsSetLogOutput(long aParams, IMessageListener aListener);
     private static native long OhNetInitParamsSetFatalErrorHandler(long aParams, IMessageListener aListener);
     private static native void OhNetInitParamsSetThreadExitHandler(long aParams, IThreadExitListener aListener);
@@ -592,6 +593,14 @@ public class InitParams
 	{
 		OhNetInitParamsSetDvEnableBonjour(iHandle, aHostName);
 	}
+	
+	/**
+	 * Set the user agent used in HTTP requests.
+	 */
+	public void setUserAgent(String aUserAgent)
+	{
+		OhNetInitParamsSetUserAgent(iHandle, aUserAgent);
+	}
     
     /**
      * Set the listener callback for log messages.
@@ -741,6 +750,7 @@ public class InitParams
 		params.setDvNumWebSocketThreads(numWebSocketThreads + 1);
 		params.setDvWebSocketPort(webSocketPort + 1);
 		params.setDvEnableBonjour("");
+    params.setUserAgent("");
 		
 		System.out.println();
 		System.out.println("Params TCP timeout:\t\t\t" + params.getTcpConnectTimeoutMs() + " ms");

--- a/OpenHome/Net/ControlPoint/Dv/CpiDeviceDv.cpp
+++ b/OpenHome/Net/ControlPoint/Dv/CpiDeviceDv.cpp
@@ -234,6 +234,11 @@ Endpoint InvocationDv::ClientEndpoint() const
     return Endpoint(0, 0);
 }
 
+Brhz InvocationDv::ClientUserAgent() const
+{
+    return Brhz();
+}
+
 void InvocationDv::InvocationReadStart()
 {
     iReadIndex = 0;

--- a/OpenHome/Net/ControlPoint/Dv/CpiDeviceDv.h
+++ b/OpenHome/Net/ControlPoint/Dv/CpiDeviceDv.h
@@ -73,6 +73,7 @@ private: // IDviInvocation
     TIpAddress Adapter() const;
     const char* ResourceUriPrefix() const;
     Endpoint ClientEndpoint() const;
+    virtual Brhz ClientUserAgent() const;
 
     void InvocationReadStart();
     TBool InvocationReadBool(const TChar* aName);

--- a/OpenHome/Net/ControlPoint/Upnp/ProtocolUpnp.cpp
+++ b/OpenHome/Net/ControlPoint/Upnp/ProtocolUpnp.cpp
@@ -179,6 +179,10 @@ void InvocationUpnp::WriteHeaders(WriterHttpRequest& aWriterRequest, const Uri& 
     Http::WriteHeaderContentLength(aWriterRequest, aBodyBytes);
     Http::WriteHeaderContentType(aWriterRequest, kContentType);
 
+    const TChar* userAgent = iCpStack.Env().InitParams()->UserAgent();
+    if (userAgent != NULL)
+        Http::WriteHeaderUserAgent(aWriterRequest, Brn(userAgent));
+
     IWriterAscii& writerField = aWriterRequest.WriteHeaderField(kSoapAction);
     writerField.Write('\"');
     WriteServiceType(writerField, iInvocation);

--- a/OpenHome/Net/Device/DviService.cpp
+++ b/OpenHome/Net/Device/DviService.cpp
@@ -338,6 +338,11 @@ Endpoint DviInvocation::ClientEndpoint() const
     return iInvocation.ClientEndpoint();
 }
 
+Brhz DviInvocation::ClientUserAgent() const
+{
+    return iInvocation.ClientUserAgent();
+}
+
 
 // DviInvocationResponseBool
 

--- a/OpenHome/Net/Device/DviService.h
+++ b/OpenHome/Net/Device/DviService.h
@@ -30,6 +30,7 @@ public:
     virtual TIpAddress Adapter() const = 0;
     virtual const char* ResourceUriPrefix() const = 0;
     virtual Endpoint ClientEndpoint() const = 0;
+    virtual Brhz ClientUserAgent() const = 0;
 
     virtual void InvocationReadStart() = 0;
     virtual TBool InvocationReadBool(const TChar* aName) = 0;
@@ -125,6 +126,7 @@ public:
     virtual TIpAddress Adapter() const;
     virtual const char* ResourceUriPrefix() const;
     virtual Endpoint ClientEndpoint() const;
+    virtual Brhz ClientUserAgent() const;
 private:
     IDviInvocation& iInvocation;
 };

--- a/OpenHome/Net/Device/Lpec/DviServerLpec.cpp
+++ b/OpenHome/Net/Device/Lpec/DviServerLpec.cpp
@@ -687,6 +687,11 @@ Endpoint DviSessionLpec::ClientEndpoint() const
     return ep;
 }
 
+Brhz DviSessionLpec::ClientUserAgent() const
+{
+    return Brhz(); // TODO
+}
+
 void DviSessionLpec::InvocationReadStart()
 {
     // nothing to do here

--- a/OpenHome/Net/Device/Lpec/DviServerLpec.h
+++ b/OpenHome/Net/Device/Lpec/DviServerLpec.h
@@ -132,6 +132,7 @@ private: // from IDviInvocation
     TIpAddress Adapter() const;
     const char* ResourceUriPrefix() const;
     Endpoint ClientEndpoint() const;
+    Brhz ClientUserAgent() const;
     void InvocationReadStart();
     TBool InvocationReadBool(const TChar* aName);
     void InvocationReadString(const TChar* aName, Brhz& aString);

--- a/OpenHome/Net/Device/Upnp/DviServerUpnp.cpp
+++ b/OpenHome/Net/Device/Upnp/DviServerUpnp.cpp
@@ -547,6 +547,7 @@ DviSessionUpnp::DviSessionUpnp(DvStack& aDvStack, TIpAddress aInterface, TUint a
     iReaderRequest->AddHeader(iHeaderNt);
     iReaderRequest->AddHeader(iHeaderCallback);
     iReaderRequest->AddHeader(iHeaderAcceptLanguage);
+    iReaderRequest->AddHeader(iHeaderUserAgent);
 
     iPropertyWriterFactory = new PropertyWriterFactory(iDvStack, aInterface, aPort);
 }
@@ -1026,6 +1027,14 @@ Endpoint DviSessionUpnp::ClientEndpoint() const
 {
     Endpoint ep(SocketTcpSession::ClientEndpoint());
     return ep;
+}
+
+Brhz DviSessionUpnp::ClientUserAgent() const
+{
+    if (!iHeaderUserAgent.Received())
+        return Brhz();
+
+    return Brhz(iHeaderUserAgent.UserAgent());
 }
 
 void DviSessionUpnp::InvocationReadStart()

--- a/OpenHome/Net/Device/Upnp/DviServerUpnp.h
+++ b/OpenHome/Net/Device/Upnp/DviServerUpnp.h
@@ -178,6 +178,7 @@ private: // IDviInvocation
     TIpAddress Adapter() const;
     const char* ResourceUriPrefix() const;
     Endpoint ClientEndpoint() const;
+    Brhz ClientUserAgent() const;
     void InvocationReadStart();
     TBool InvocationReadBool(const TChar* aName);
     void InvocationReadString(const TChar* aName, Brhz& aString);
@@ -226,6 +227,7 @@ private:
     HeaderNt iHeaderNt;
     HeaderCallback iHeaderCallback;
     HeaderAcceptLanguage iHeaderAcceptLanguage;
+    HttpHeaderUserAgent iHeaderUserAgent;
     const HttpStatus* iErrorStatus;
     TBool iResponseStarted;
     TBool iResponseEnded;

--- a/OpenHome/Net/OhNet.cpp
+++ b/OpenHome/Net/OhNet.cpp
@@ -407,6 +407,11 @@ void InitialisationParams::SetTimerManagerPriority(uint32_t aPriority)
     iTimerManagerThreadPriority = aPriority;
 }
 
+void InitialisationParams::SetUserAgent(const TChar* aUserAgent)
+{
+    iUserAgent.Set(aUserAgent);
+}
+
 FunctorMsg& InitialisationParams::LogOutput()
 {
     return iLogOutput;
@@ -580,6 +585,11 @@ bool InitialisationParams::IsHostUdpLowQuality()
 uint32_t InitialisationParams::TimerManagerPriority() const
 {
     return iTimerManagerThreadPriority;
+}
+
+const TChar* InitialisationParams::UserAgent() const
+{
+    return iUserAgent.CString();
 }
 
 #if defined(PLATFORM_MACOSX_GNU) || defined (PLATFORM_IOS)

--- a/OpenHome/Net/OhNet.h
+++ b/OpenHome/Net/OhNet.h
@@ -370,6 +370,11 @@ public:
      */
     void SetTimerManagerPriority(uint32_t aPriority);
 
+    /**
+     * Set the user agent used in HTTP requests.
+     */
+    void SetUserAgent(const TChar* aUserAgent);
+
     FunctorMsg& LogOutput();
     FunctorMsg& FatalErrorHandler();
     FunctorAsync& AsyncBeginHandler();
@@ -404,6 +409,7 @@ public:
     uint32_t DvLpecServerPort();
     bool IsHostUdpLowQuality();
     uint32_t TimerManagerPriority() const;
+    const TChar* UserAgent() const;
 private:
     InitialisationParams();
     void FatalErrorHandlerDefault(const char* aMsg);
@@ -445,6 +451,7 @@ private:
     uint32_t iDvNumLpecThreads;
     uint32_t iDvLpecServerPort;
     uint32_t iTimerManagerThreadPriority;
+    Brhz iUserAgent;
 };
 
 class CpStack;


### PR DESCRIPTION
I'm pretty new to OpenHome and ohNet but I really like the way it's setup.
So far the only downside I've come across is that there is basically no way to "identify" a UPnP client based on its request to a MediaServer implementation (e.g. `Browse`) because the only available information from the `IDviInvocation` object is the client's IP address and port (which is not really unique). Most implementations of UPnP servers I know use the value of the `User-Agent` HTTP header which often contains the client's name.

So I've tried to extend `IDviInvocation` to provide this information if available. Right now only `DviServerUpnp` provides this information. I'm not sure if it's also available from the `DviServerWebsocket` implementation (which however doesn't derive from `IDviInvocation`) and I don't really know what `DviServerLpec` is. I also don't really understand all the string buffer implementations yet so chances are high that I did something wrong there.

I've only tested the C++ bindings implementation. The other bindings imlementations (C, C# and JNI) are copy & pasted and untested.

TODOs:
- [ ] use the proper string buffer implementation
- [ ] fix `DviServerLpec`
- [ ] review/validate C bindings
- [ ] review/validate C# bindings
- [ ] review/validate Java/JNI bindings
- [ ] squash the commits if necessary
