### PR TITLE
Prefer mcs over dmcs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -361,7 +361,7 @@ endif
 ifeq ($(platform), iOS)
 	csharp = /Developer/MonoTouch/usr/bin/smcs /nologo $(debug_csharp)
 else
-	csharp = dmcs /nologo $(debug_csharp)
+	csharp = mcs /nologo $(debug_csharp)
 endif
 csharpdefines ?=
 publicjavadir = OpenHome/Net/Bindings/Java/

--- a/T4Linux.mak
+++ b/T4Linux.mak
@@ -32,7 +32,7 @@ dllsources =	OpenHome/Net/T4/TextTemplating/Mono.TextTemplating/AssemblyInfo.cs 
 
 $(toolsDir)Mono.TextTemplating.dll : $(dllsources)
 	$(mkdir) $(toolsDir)
-	dmcs /t:library -out:$(toolsDir)Mono.TextTemplating.dll $(dllsources)
+	mcs /t:library -out:$(toolsDir)Mono.TextTemplating.dll $(dllsources)
 
  
 exesources =	OpenHome/Net/T4/TextTemplating/TextTransform/AssemblyInfo.cs \
@@ -41,11 +41,11 @@ exesources =	OpenHome/Net/T4/TextTemplating/TextTransform/AssemblyInfo.cs \
 
 $(toolsDir)OhNetGen.exe : $(toolsDir)TextTransform.exe OpenHome/Net/T4/OhNetGen.cs
 	$(mkdir) $(toolsDir)
-	dmcs /t:exe /out:$(toolsDir)OhNetGen.exe OpenHome/Net/T4/OhNetGen.cs OpenHome/Net/T4/AssemblyInfo.cs
+	mcs /t:exe /out:$(toolsDir)OhNetGen.exe OpenHome/Net/T4/OhNetGen.cs OpenHome/Net/T4/AssemblyInfo.cs
 
 $(toolsDir)TextTransform.exe : $(toolsDir)Mono.TextTemplating.dll $(exesources)
 	$(mkdir) $(toolsDir)
-	dmcs /t:exe -out:$(toolsDir)TextTransform.exe /r:$(toolsDir)Mono.TextTemplating.dll $(exesources)
+	mcs /t:exe -out:$(toolsDir)TextTransform.exe /r:$(toolsDir)Mono.TextTemplating.dll $(exesources)
 
 $(toolsDir)UpnpServiceDescription.xsd : OpenHome/Net/T4/UpnpServiceXml/UpnpServiceDescription.xsd
 	$(mkdir) $(toolsDir)
@@ -60,14 +60,14 @@ xmlsources = 	OpenHome/Net/T4/UpnpServiceXml/AssemblyInfo.cs \
 
 $(toolsDir)UpnpServiceXml.dll: $(toolsDir)UpnpServiceDescription.xsd $(toolsDir)UpnpServiceTemplate.xsd $(xmlsources)
 	$(mkdir) $(toolsDir)
-	dmcs -target:library -out:$(upnpServiceXml) $(xmlsources)
+	mcs -target:library -out:$(upnpServiceXml) $(xmlsources)
 	
 upnpservicemake.sources =   OpenHome/Net/T4/UpnpServiceMake/AssemblyInfo.cs \
                             OpenHome/Net/T4/UpnpServiceMake/UpnpServiceMake.cs
 
 $(toolsDir)UpnpServiceMake.dll : $(upnpservicemake.sources)
 	$(mkdir) $(toolsDir)
-	dmcs -target:library -out:$(upnpServiceMake) $(upnpservicemake.sources)
+	mcs -target:library -out:$(upnpServiceMake) $(upnpservicemake.sources)
 
 clean-t4:
 	if test -d $(toolsDir); then $(rmdir) $(toolsDir); fi


### PR DESCRIPTION
This gets rid of `warning CS8001: SDK path could not be resolved` error while compiling.